### PR TITLE
generic: backport upstream r8169 irq patch

### DIFF
--- a/target/linux/generic/backport-6.6/780-22-v6.12-r8169-add-support-for-RTL8126A-rev.b.patch
+++ b/target/linux/generic/backport-6.6/780-22-v6.12-r8169-add-support-for-RTL8126A-rev.b.patch
@@ -1,7 +1,7 @@
 From 69cb89981c7a181d857b634c0740e914d5df79ea Mon Sep 17 00:00:00 2001
 From: ChunHao Lin <hau@realtek.com>
 Date: Fri, 30 Aug 2024 10:18:10 +0800
-Subject: [PATCH 43/47] r8169: add support for RTL8126A rev.b
+Subject: [PATCH] r8169: add support for RTL8126A rev.b
 
 Add support for RTL8126A rev.b. Its XID is 0x64a. It is basically
 based on the one with XID 0x649, but with different firmware file.

--- a/target/linux/generic/backport-6.6/780-23-v6.12-r8169-add-missing-MODULE_FIRMWARE-entry-for-RTL8126A.patch
+++ b/target/linux/generic/backport-6.6/780-23-v6.12-r8169-add-missing-MODULE_FIRMWARE-entry-for-RTL8126A.patch
@@ -1,8 +1,7 @@
 From 3b067536daa4842adbf685accf47c899a26367d3 Mon Sep 17 00:00:00 2001
 From: Heiner Kallweit <hkallweit1@gmail.com>
 Date: Wed, 18 Sep 2024 20:45:15 +0200
-Subject: [PATCH 47/47] r8169: add missing MODULE_FIRMWARE entry for RTL8126A
- rev.b
+Subject: [PATCH] r8169: add missing MODULE_FIRMWARE entry for RTL8126A rev.b
 
 Add a missing MODULE_FIRMWARE entry.
 

--- a/target/linux/generic/backport-6.6/780-24-v6.12-r8169-avoid-unsolicited-interrupts.patch
+++ b/target/linux/generic/backport-6.6/780-24-v6.12-r8169-avoid-unsolicited-interrupts.patch
@@ -1,0 +1,39 @@
+From 10ce0db787004875f4dba068ea952207d1d8abeb Mon Sep 17 00:00:00 2001
+From: Heiner Kallweit <hkallweit1@gmail.com>
+Date: Fri, 18 Oct 2024 11:08:16 +0200
+Subject: [PATCH] r8169: avoid unsolicited interrupts
+
+It was reported that after resume from suspend a PCI error is logged
+and connectivity is broken. Error message is:
+PCI error (cmd = 0x0407, status_errs = 0x0000)
+The message seems to be a red herring as none of the error bits is set,
+and the PCI command register value also is normal. Exception handling
+for a PCI error includes a chip reset what apparently brakes connectivity
+here. The interrupt status bit triggering the PCI error handling isn't
+actually used on PCIe chip versions, so it's not clear why this bit is
+set by the chip. Fix this by ignoring this bit on PCIe chip versions.
+
+Fixes: 0e4851502f84 ("r8169: merge with version 8.001.00 of Realtek's r8168 driver")
+Closes: https://bugzilla.kernel.org/show_bug.cgi?id=219388
+Tested-by: Atlas Yu <atlas.yu@canonical.com>
+Signed-off-by: Heiner Kallweit <hkallweit1@gmail.com>
+Reviewed-by: Simon Horman <horms@kernel.org>
+Link: https://patch.msgid.link/78e2f535-438f-4212-ad94-a77637ac6c9c@gmail.com
+Signed-off-by: Paolo Abeni <pabeni@redhat.com>
+---
+ drivers/net/ethernet/realtek/r8169_main.c | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+--- a/drivers/net/ethernet/realtek/r8169_main.c
++++ b/drivers/net/ethernet/realtek/r8169_main.c
+@@ -4683,7 +4683,9 @@ static irqreturn_t rtl8169_interrupt(int
+ 	if ((status & 0xffff) == 0xffff || !(status & tp->irq_mask))
+ 		return IRQ_NONE;
+ 
+-	if (unlikely(status & SYSErr)) {
++	/* At least RTL8168fp may unexpectedly set the SYSErr bit */
++	if (unlikely(status & SYSErr &&
++	    tp->mac_version <= RTL_GIGA_MAC_VER_06)) {
+ 		rtl8169_pcierr_interrupt(tp->dev);
+ 		goto out;
+ 	}


### PR DESCRIPTION
This commit backports an additional patch from linux v6.12 release.
